### PR TITLE
Update plugin.xml

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -29,7 +29,7 @@
             </feature>
         </config-file>
 
-        <source-file src="src/android/NativeAudio.java" target-dir="src/de/neofonie/cordova/plugin/nativeaudio"/>
+        <source-file src="src/android/nativeaudio.java" target-dir="src/de/neofonie/cordova/plugin/nativeaudio"/>
         <source-file src="src/android/NativeAudioAsset.java" target-dir="src/de/neofonie/cordova/plugin/nativeaudio"/>
         <source-file src="src/android/NativeAudioAssetComplex.java" target-dir="src/de/neofonie/cordova/plugin/nativeaudio"/>
 


### PR DESCRIPTION
Fixes nativeaudio.java path for android configuration.

plugman is looking for NativeAudio.java which doesn't exist and returning

```
Error: Uh oh!
"/path/to/project/plugins/de.neofonie.cordova.plugin.nativeaudio/src/android/NativeAudio.java" not found!
```
