### PR TITLE
Fixed build issues on Android using API 19

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -34,9 +34,9 @@
         <source-file src="src/android/NativeAudioAssetComplex.java" target-dir="src/de/neofonie/cordova/plugin/nativeaudio"/>
 
         <config-file target="AndroidManifest.xml" parent="/*">
-            <uses-permission name="android.permission.MODIFY_AUDIO_SETTINGS"/>
-            <uses-permission name="android.permission.WRITE_EXTERNAL_STORAGE"/>
-            <uses-permission name="android.permission.READ_PHONE_STATE"/>
+            <uses-permission android:name="android.permission.MODIFY_AUDIO_SETTINGS"/>
+            <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>
+            <uses-permission android:name="android.permission.READ_PHONE_STATE"/>
         </config-file>
 
     </platform>


### PR DESCRIPTION
I was receiving these errors when using this plugin for Android API 19:
```
     [aapt] /Users/sashasirotkin/Projects/REDACTED/platforms/android/ant-build/AndroidManifest.xml:19: Tag <uses-permission> missing required attribute name.
     [aapt] /Users/sashasirotkin/Projects/REDACTED/platforms/android/ant-build/AndroidManifest.xml:20: Tag <uses-permission> missing required attribute name.
     [aapt] /Users/sashasirotkin/Projects/REDACTED/platforms/android/ant-build/AndroidManifest.xml:21: Tag <uses-permission> missing required attribute name.

BUILD FAILED
/usr/local/opt/android-sdk/tools/ant/build.xml:653: The following error occurred while executing this line:
/usr/local/opt/android-sdk/tools/ant/build.xml:698: null returned: 1
```

The recommended changes fixes this issue.

Really surprised it wasn't caught before!