### PR TITLE
fix:ios Move the increase of volume to the main thread

### DIFF
--- a/src/ios/NativeAudioAsset.m
+++ b/src/ios/NativeAudioAsset.m
@@ -69,14 +69,18 @@ static const CGFloat FADE_DELAY = 0.08;
         [player play];
         playIndex += 1;
         playIndex = playIndex % [voices count];
-        [self performSelector:@selector(playWithFade) withObject:nil afterDelay:fadeDelay.floatValue];
+        dispatch_async(dispatch_get_main_queue(), ^{
+            [self performSelector:@selector(playWithFade) withObject:nil afterDelay:fadeDelay.floatValue];
+        });
     }
     else
     {
         if(player.volume < initialVolume.floatValue)
         {
             player.volume += FADE_STEP;
-            [self performSelector:@selector(playWithFade) withObject:nil afterDelay:fadeDelay.floatValue];
+            dispatch_async(dispatch_get_main_queue(), ^{
+                [self performSelector:@selector(playWithFade) withObject:nil afterDelay:fadeDelay.floatValue];
+            });
         }
     }
 }


### PR DESCRIPTION
Audio clip plays but no sound. Problem happens on iPhone 6+ on ios 8.1 and emulator.

After some trace, it turns out playWithFade is only called once and performSelector:withObject:afterDelay isn't triggered. I think it's because the thread calling playWithFade finishes and dies after the first call. Then, any timers scheduled with performSelector:withObject:afterDelay are dropped.

In this PR, I've scheduled the delay call in the main queue and now everything works as expected.
Not an experienced iOS developer myself, I am not sure if scheduling playWithFade in the main thread is the most appropriate fix. However, I haven't seen any issues that affects rendering so far.